### PR TITLE
add news for LOINC--DO NOT merge yet

### DIFF
--- a/news.json
+++ b/news.json
@@ -1,10 +1,10 @@
 {
      "April 2019": [
        {
-         "title": "New HPO Release",
-         "date": "April 15, 2019",
-         "body": "The HPO Team has created a new release for April 2019 ontology & annotations. There is also a new web release with some upgraded features such as LOINC annotations for terms, <a href=\"https://hpo.jax.org/app/help/publications\" target=\"__blank\"> a new way to browse </a> related publications, and minor updates to the term hierarchy. <br><br> Please let us know of any features you would like in the near future on our issue <a href=\"https://github.com/TheJacksonLaboratory/hpo-web/issues\" target=\"__blank\">tracker</a>, we look forward to your feedback! <br>Regards,<br><br> The HPO Team",
-         "terserTitle": "New HPO-Web 1.5, HP-OBO April"
+         "title": "HPO Web Application Release and Ontology Synchronization",
+         "date": "April 16, 2019",
+         "body": "The HPO Team has a new web release with some upgraded features such as LOINC annotations for terms, <a href=\"https://hpo.jax.org/app/help/publications\" target=\"__blank\"> a new way to browse </a> related publications, and minor updates to the term hierarchy. <br><br> Please let us know of any features you would like in the near future on our issue <a href=\"https://github.com/TheJacksonLaboratory/hpo-web/issues\" target=\"__blank\">tracker</a>, we look forward to your feedback! <br>Regards,<br><br> The HPO Team",
+         "terserTitle": "HPO-Web 1.5, HP-OBO April"
        },  
        {
          "title": "LOINC2HPO accepted for publication",

--- a/news.json
+++ b/news.json
@@ -1,4 +1,12 @@
 {
+     "April 2019": [
+       {
+         "title": "LOINC2HPO accepted for publication",
+         "date": "April 8, 2019",
+         "body": "A manuscript that describes our effort in converting LOINC-coded clinical lab tests into HPO terms has been accepted by npj Digital Medicine. The conversion allows one to semantically integrate clinically equivalent lab tests together and aggregate patient phenotypes based on the HPO hierarchy. We demonstrated its applications in generating patient deep phenotyping profiles and biomarker screen with an asthma dataset. For details, refer to the open-access article <a href=\"https://www.biorxiv.org/content/10.1101/519231v1\" target=\"__blank\" >here</a>. ",
+         "terserTitle": "Converting lab tests into HPO terms"
+       }
+     ],
      "February 2019": [
         {
           "title": "February 2019 release",

--- a/news.json
+++ b/news.json
@@ -1,6 +1,12 @@
 {
      "April 2019": [
        {
+         "title": "New HPO Release",
+         "date": "April 15, 2019",
+         "body": "The HPO Team has created a new release for April 2019 ontology & annotations. There is also a new web release with some upgraded features such as LOINC annotations for terms, <a href=\"https://hpo.jax.org/app/help/publications\" target=\"__blank\"> a new way to browse </a> related publications, and minor updates to the term hierarchy. <br><br> Please let us know of any features you would like in the near future on our issue <a href=\"https://github.com/TheJacksonLaboratory/hpo-web/issues\" target=\"__blank\">tracker</a>, we look forward to your feedback! <br>Regards,<br><br> The HPO Team",
+         "terserTitle": "New HPO-Web 1.5, HP-OBO April"
+       },  
+       {
          "title": "LOINC2HPO accepted for publication",
          "date": "April 8, 2019",
          "body": "A manuscript that describes our effort in converting LOINC-coded clinical lab tests into HPO terms has been accepted by npj Digital Medicine. The conversion allows one to semantically integrate clinically equivalent lab tests together and aggregate patient phenotypes based on the HPO hierarchy. We demonstrated its applications in generating patient deep phenotyping profiles and biomarker screen with an asthma dataset. For details, refer to the open-access article <a href=\"https://www.biorxiv.org/content/10.1101/519231v1\" target=\"__blank\" >here</a>. ",


### PR DESCRIPTION
Add news for LOINC2HPO publication.

I recommend we hold on until the paper appears on journal website so that we can direct users to that page, instead of the preprint.